### PR TITLE
Fixed warning signs on project dependencies

### DIFF
--- a/AdminModule/AdminModule.csproj
+++ b/AdminModule/AdminModule.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.DryIoc.Forms.Extended" Version="7.2.0.661" />
+    <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1367" />
     <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
   </ItemGroup>
 

--- a/AuthModule/AuthModule.csproj
+++ b/AuthModule/AuthModule.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.DryIoc.Forms.Extended" Version="7.2.0.661" />
+    <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1367" />
+    <PackageReference Include="Prism.Plugin.Logging.Abstractions" Version="7.2.0.616" />
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
     <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
   </ItemGroup>

--- a/src/DevAssessment.Android/DevAssessment.Android.csproj
+++ b/src/DevAssessment.Android/DevAssessment.Android.csproj
@@ -53,9 +53,11 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
+    <PackageReference Include="Xamarin.Forms">
+      <Version>4.3.0.908675</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/src/DevAssessment.UWP/DevAssessment.UWP.csproj
+++ b/src/DevAssessment.UWP/DevAssessment.UWP.csproj
@@ -147,9 +147,11 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
+    <PackageReference Include="Xamarin.Forms">
+      <Version>4.3.0.908675</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DevAssessment\DevAssessment.csproj">

--- a/src/DevAssessment.iOS/DevAssessment.iOS.csproj
+++ b/src/DevAssessment.iOS/DevAssessment.iOS.csproj
@@ -123,8 +123,10 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
+    <PackageReference Include="Xamarin.Forms">
+      <Version>4.3.0.908675</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/src/DevAssessment/App.xaml
+++ b/src/DevAssessment/App.xaml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<prism:PrismApplication xmlns="http://xamarin.com/schemas/2014/forms" 
-                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
-                        xmlns:prism="http://prismlibrary.com" 
-                        x:Class="DevAssessment.App">
-    <prism:PrismApplication.Resources>
+<prism:PrismApplication xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="clr-namespace:Prism.DryIoc;assembly=Prism.DryIoc.Forms"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" x:Class="DevAssessment.App">
+  <prism:PrismApplication.Resources>
 
-    </prism:PrismApplication.Resources>
+  </prism:PrismApplication.Resources>
 </prism:PrismApplication>

--- a/src/DevAssessment/App.xaml.cs
+++ b/src/DevAssessment/App.xaml.cs
@@ -2,6 +2,7 @@
 using AuthModule;
 using AuthModule.Events;
 using DevAssessment.Services;
+using DryIoc;
 using Prism;
 using Prism.Events;
 using Prism.Ioc;
@@ -56,6 +57,11 @@ namespace DevAssessment
             });
         }
 
+        protected override Rules CreateContainerRules()
+        {
+            return base.CreateContainerRules().WithoutThrowOnRegisteringDisposableTransient();
+        }
+
         private async void NavigateAuthenticatedUser(string accessToken)
         {
             await NavigationService.NavigateAsync("/MainPage/NavigationPage/HomePage", ("access_token", accessToken));
@@ -63,7 +69,7 @@ namespace DevAssessment
 
         private async void NavigateLoggedOutUser()
         {
-            var moduleList = ModuleCatalog.Modules.ToList();
+            var moduleList = Container.Resolve<IModuleCatalog>().Modules.ToList();
             var adminModule = moduleList.Find(x => x.ModuleName.Equals(nameof(AdministratorModule)));
 
             if (adminModule != null)

--- a/src/DevAssessment/DevAssessment.csproj
+++ b/src/DevAssessment/DevAssessment.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.DryIoc.Forms.Extended" Version="7.2.0.661" />
+    <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1367" />
+    <PackageReference Include="Prism.Plugin.Logging.Abstractions" Version="7.2.0.616" />
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
     <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
   </ItemGroup>


### PR DESCRIPTION
## Overview
- UnInstalled Xamarin.Forms and Prism.DryIoc.Forms.Extended
- Re-installed Prism.DryIoc.Forms
- Re-installed Xamarin.Forms
- Replaced xmlns:prism="clr-namespace:Prism.DryIoc;assembly=Prism.DryIoc.Forms" in App.xaml
- Installed Prism.Plugin.Logging.Abstractions
- Added Rule for ITextSpeechService in App.xaml.cs
